### PR TITLE
giving the drought endpoint priority run

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -7,6 +7,18 @@
   "data": {
     "projects": [
       {
+        "name": "Drought",
+        "enabled": true,
+        "WordPressUrl": "https://live-drought-ca-gov.pantheonsite.io",
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "drought.ca.gov",
+          "Branch": "main",
+          "PostPath": "wordpress/posts",
+          "PagePath": "wordpress/pages"
+        }
+      },
+      {
         "name": "Covid 19 website",
         "enabled": false,
         "WordPressUrl": "https://as-go-covid19-d-001.azurewebsites.net",
@@ -39,18 +51,6 @@
         "GitHubTarget": {
           "Owner": "cagov",
           "Repo": "cannabis.ca.gov",
-          "Branch": "main",
-          "PostPath": "wordpress/posts",
-          "PagePath": "wordpress/pages"
-        }
-      },
-      {
-        "name": "Drought",
-        "enabled": true,
-        "WordPressUrl": "https://live-drought-ca-gov.pantheonsite.io",
-        "GitHubTarget": {
-          "Owner": "cagov",
-          "Repo": "drought.ca.gov",
           "Branch": "main",
           "PostPath": "wordpress/posts",
           "PagePath": "wordpress/pages"


### PR DESCRIPTION
This will make the drought site check first, improving turn-around.