### PR TITLE
fix missing media syncing

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -53,7 +53,9 @@
           "Repo": "drought.ca.gov",
           "Branch": "main",
           "PostPath": "wordpress/posts",
-          "PagePath": "wordpress/pages"
+          "PagePath": "wordpress/pages",
+          "MediaPath": "wordpress/media",
+          "SyncMedia": true
         }
       }
     ]


### PR DESCRIPTION
@carterm  the MediaSync was missing. This worked from my PR branch, adding the variables in the config runs (and adding missing images to wordpress... but I see some new errors - can you take a look?) 


(node:16229) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'data' of undefined
  /node_modules/github-api/dist/components/Requestable.js:238:29
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
....