### PR TITLE
disabling cannabis endpoint

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -53,7 +53,7 @@
       },
       {
         "name": "Cannabis",
-        "enabled": true,
+        "enabled": false,
         "enabledLocal": false,
         "WordPressUrl": "https://staginginye.prod3.sites.ca.gov",
         "GitHubTarget": {


### PR DESCRIPTION
Authentication is now required for cannabis WP, so we can't use it anymore.