### PR TITLE
Add development targets for cannabis and drought sites. 

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -18,6 +18,17 @@
         }
       },
       {
+        "name": "Drought development",
+        "enabled": true,
+        "enabledLocal": true,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "drought.ca.gov",
+          "Branch": "development",
+          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+        }
+      },
+      {
         "name": "Cannabis",
         "enabled": true,
         "enabledLocal": false,
@@ -25,6 +36,17 @@
           "Owner": "cagov",
           "Repo": "cannabis.ca.gov",
           "Branch": "main",
+          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+        }
+      },
+      {
+        "name": "Cannabis development",
+        "enabled": false,
+        "enabledLocal": false,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "cannabis.ca.gov",
+          "Branch": "development",
           "ConfigPath": "wordpress/wordpress-to-github.config.json"
         }
       },


### PR DESCRIPTION
Configs and buckets already set up for these instances & tested running the debugger.