### PR TITLE
Update endpoints for cannabis.ca.gov

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -28,48 +28,92 @@
           "ConfigPath": "wordpress/wordpress-to-github.config.json"
         }
       },
-      {
-        "name": "Cannabis",
+  {
+        "name": "headless.cannabis.ca.gov",
         "enabled": true,
         "enabledLocal": false,
         "GitHubTarget": {
           "Owner": "cagov",
           "Repo": "cannabis.ca.gov",
           "Branch": "main",
-          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+          "ConfigPath": "wordpress/config/wordpress-to-github.config.json"
         }
       },
       {
-        "name": "Cannabis Flywheel Staging",
+        "name": "staging.cannabis.ca.gov",
         "enabled": true,
         "enabledLocal": false,
         "GitHubTarget": {
           "Owner": "cagov",
           "Repo": "cannabis.ca.gov",
           "Branch": "staging",
-          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+          "ConfigPath": "wordpress/config/wordpress-to-github.staging.config.json"
         }
       },
       {
-        "name": "Cannabis Pantheon Staging",
-        "enabled": true,
-        "enabledLocal": false,
-        "GitHubTarget": {
-          "Owner": "cagov",
-          "Repo": "cannabis.ca.gov",
-          "Branch": "staging-pantheon",
-          "ConfigPath": "wordpress/wordpress-to-github.config.json"
-        }
-      },
-      {
-        "name": "Cannabis development",
+        "name": "development.cannabis.ca.gov",
         "enabled": true,
         "enabledLocal": false,
         "GitHubTarget": {
           "Owner": "cagov",
           "Repo": "cannabis.ca.gov",
           "Branch": "development",
-          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+          "ConfigPath": "wordpress/config/wordpress-to-github.development.config.json"
+        }
+      },
+      {
+        "name": "staging-pantheon.ca.gov",
+        "enabled": true,
+        "enabledLocal": false,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "cannabis.ca.gov",
+          "Branch": "staging-pantheon",
+          "ConfigPath": "wordpress/config/wordpress-to-github.staging-pantheon.config.json"
+        }
+      },
+      {
+        "name": "development-pantheon.cannabis.ca.gov",
+        "enabled": true,
+        "enabledLocal": false,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "cannabis.ca.gov",
+          "Branch": "development-pantheon",
+          "ConfigPath": "wordpress/config/wordpress-to-github.development-pantheon.config.json"
+        }
+      },
+      {
+        "name": "main-wp58.cannabis.ca.gov",
+        "enabled": true,
+        "enabledLocal": false,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "cannabis.ca.gov",
+          "Branch": "main-wp58",
+          "ConfigPath": "wordpress/config/wordpress-to-github.main-wp58.config.json"
+        }
+      },
+      {
+        "name": "staging-wp58.cannabis.ca.gov",
+        "enabled": true,
+        "enabledLocal": false,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "cannabis.ca.gov",
+          "Branch": "staging-wp58",
+          "ConfigPath": "wordpress/config/wordpress-to-github.staging-wp58.config.json"
+        }
+      },
+      {
+        "name": "development-wp58.cannabis.ca.gov",
+        "enabled": true,
+        "enabledLocal": false,
+        "GitHubTarget": {
+          "Owner": "cagov",
+          "Repo": "cannabis.ca.gov",
+          "Branch": "development-wp58",
+          "ConfigPath": "wordpress/config/wordpress-to-github.development-wp58.config.json"
         }
       },
       {

--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -62,7 +62,7 @@
         }
       },
       {
-        "name": "staging-pantheon.ca.gov",
+        "name": "staging-pantheon.cannabis.ca.gov",
         "enabled": true,
         "enabledLocal": false,
         "GitHubTarget": {


### PR DESCRIPTION
* Updated all the configs in cannabis branch for our different WP instances & clones.
* Files are named by environment to prevent overrides (Already had an override situation with a faulty merge)
* Created new config folder to make syncing file sets easier.
* Added endpoints file for cannabis.ca.gov in cannabis.ca.gov repo as backup.
* All these instances are tracked in ODI Publishing folder in Google Drive.