### PR TITLE
Default route will use the Trigger site now

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -1,4 +1,15 @@
 {
   "$schema": "http://json.schemastore.org/proxies",
-  "proxies": {}
+  "proxies": {
+    "RootProxy": {
+      "desc": [
+        "Great examples here - https://gist.github.com/sjkp/890d94b958965898e45e69bf199c88d4#file-proxies-json-L75"
+      ],
+      "matchCondition": {
+        "methods": ["GET", "POST"],
+        "route": "/"
+      },
+      "backendUri": "https://%WEBSITE_HOSTNAME%/WordpressSyncHttpTrigger"
+    }
+  }
 }


### PR DESCRIPTION
Proxy file feature that will let trigger users send POST/GET to the function site root instead of the trigger name.

Tested that the `Code=` query elements will be properly maintained.


Instead of...
`https://[function site].azurewebsites.net/WordPressSyncHttpTrigger?code=[code]`

You can now use...
`https://[function site].azurewebsites.net?code=[code]`

