### PR TITLE
Removing resolution note in slack

### DIFF
--- a/WordpressSync/index.js
+++ b/WordpressSync/index.js
@@ -98,7 +98,7 @@ const doProcessEndpoints = async work => {
                   .split("/")
                   .slice(-1)[0]
                   .split(".")[0]
-                  .replace(/-\d+x\d+$/, "")
+                  .replace(/-\d{1,4}x\d{1,4}$/, "")
             )
           );
         });

--- a/WordpressSync/index.js
+++ b/WordpressSync/index.js
@@ -92,7 +92,13 @@ const doProcessEndpoints = async work => {
         commitReports.map(x => {
           mergeFileNames.push(
             ...x.Files.map(
-              x => x.filename.split("/").slice(-1)[0].split(".")[0]
+              //Remove file extension, and remove resolution postfix
+              x =>
+                x.filename
+                  .split("/")
+                  .slice(-1)[0]
+                  .split(".")[0]
+                  .replace(/-\d+x\d+$/, "")
             )
           );
         });


### PR DESCRIPTION
This will remove the extra notifications in the slack thread that include `-000x000`.  They will still be displayed in the reply details, but not in the initial note.

Slack main thread will say...

> Covid 19 website - cropped-ms-icon-310x310-1, cropped-thumbnail

while the reply note will list...

> • added - cropped-ms-icon-310x310-1-150x150.png
> • added - cropped-ms-icon-310x310-1-180x180.png
> • added - cropped-ms-icon-310x310-1-192x192.png
> • added - cropped-ms-icon-310x310-1-270x270.png
> • added - cropped-ms-icon-310x310-1-300x300.png
> • added - cropped-ms-icon-310x310-1-32x32.png
> • added - cropped-ms-icon-310x310-1.json
> • added - cropped-ms-icon-310x310-1.png
> • added - cropped-thumbnail-150x150.png
> • added - cropped-thumbnail-180x180.png
> • added - cropped-thumbnail-192x192.png
> • added - cropped-thumbnail-270x270.png
> • added - cropped-thumbnail-300x300.png
> • added - cropped-thumbnail-32x32.png
> • added - cropped-thumbnail.json
> • added - cropped-thumbnail.png