### PR TITLE
Adding object url to output

### DIFF
--- a/wordpress-to-github/common/index.js
+++ b/wordpress-to-github/common/index.js
@@ -154,10 +154,12 @@ const pathFromMediaSourceUrl = source_url =>
  *
  * @param {string} wordpress_source_url
  * @param {GitHubTarget} gitHubTarget
+ * @param {string} object_url
  */
-const commonMeta = (wordpress_source_url, gitHubTarget) => ({
+const commonMeta = (wordpress_source_url, gitHubTarget, object_url) => ({
   api_version: "v2",
   api_url: wordpress_source_url + apiPath,
+  object_url,
   process: {
     source_code: "https://github.com/cagov/wordpress-to-github",
     source_data: wordpress_source_url,
@@ -295,18 +297,20 @@ const fetchDictionary = async (wordPressApiUrl, listname) =>
  * @param {GitHubTarget} gitHubTarget
  * @param {string} field_reference //url for field refernce
  * @param {GithubOutputJson} data
+ * @param {string} object_url
  */
 const wrapInFileMeta = (
   wordpress_source_url,
   gitHubTarget,
   field_reference,
-  data
+  data,
+  object_url
 ) => ({
   meta: {
     created_date: data.date_gmt,
     updated_date: data.modified_gmt,
     field_reference,
-    ...commonMeta(wordpress_source_url, gitHubTarget)
+    ...commonMeta(wordpress_source_url, gitHubTarget, object_url)
   },
   data
 });

--- a/wordpress-to-github/index.js
+++ b/wordpress-to-github/index.js
@@ -180,10 +180,9 @@ const SyncEndpoint = async (
   }
 
   if (endpointConfig.GeneralFilePath) {
+    const targetUrl = `${sourceEndpointConfig.WordPressSource.url}/wp-json?_fields=description,gmt_offset,name,namespaces,timezone_string,home,url`;
     const fetchResponse = await WpApi_getSomething(
-      `${
-        sourceEndpointConfig.WordPressSource.url
-      }/wp-json/?_fields=description,gmt_offset,name,namespaces,timezone_string,home,url&cachebust=${Math.random()}`
+      `${targetUrl}&cachebust=${Math.random()}`
     );
 
     const data = await fetchResponse.json();
@@ -191,7 +190,11 @@ const SyncEndpoint = async (
 
     const jsonData = {
       meta: {
-        ...commonMeta(sourceEndpointConfig.WordPressSource.url, gitHubTarget)
+        ...commonMeta(
+          sourceEndpointConfig.WordPressSource.url,
+          gitHubTarget,
+          targetUrl
+        )
       },
       data
     };
@@ -244,6 +247,9 @@ const SyncEndpoint = async (
         )
       };
 
+      /** @type {string} */
+      const object_url = jsonData["_links"]?.self[0].href;
+
       removeExcludedProperties(jsonData, endpointConfig.ExcludeProperties);
 
       if (x.media_details.sizes && Object.keys(x.media_details.sizes).length) {
@@ -273,7 +279,8 @@ const SyncEndpoint = async (
           sourceEndpointConfig.WordPressSource.url,
           gitHubTarget,
           fieldMetaReference.media,
-          jsonData
+          jsonData,
+          object_url
         )
       );
     });
@@ -381,6 +388,9 @@ const SyncEndpoint = async (
 
       addMediaSection(endpointConfig, mediaMap, jsonData, HTML);
 
+      /** @type {string} */
+      const object_url = jsonData["_links"]?.self[0].href;
+
       removeExcludedProperties(jsonData, endpointConfig.ExcludeProperties);
 
       const ignoreThisOne = anythingInArrayMatch(
@@ -396,7 +406,8 @@ const SyncEndpoint = async (
               sourceEndpointConfig.WordPressSource.url,
               gitHubTarget,
               fieldMetaReference.posts,
-              jsonData
+              jsonData,
+              object_url
             )
       );
       postMap.set(`${x.slug}.html`, ignoreThisOne ? null : HTML);
@@ -431,6 +442,9 @@ const SyncEndpoint = async (
 
       addMediaSection(endpointConfig, mediaMap, jsonData, HTML);
 
+      /** @type {string} */
+      const object_url = jsonData["_links"]?.self[0].href;
+
       removeExcludedProperties(jsonData, endpointConfig.ExcludeProperties);
 
       const ignoreThisOne = anythingInArrayMatch(
@@ -446,7 +460,8 @@ const SyncEndpoint = async (
               sourceEndpointConfig.WordPressSource.url,
               gitHubTarget,
               fieldMetaReference.media,
-              jsonData
+              jsonData,
+              object_url
             )
       );
       pagesMap.set(`${x.slug}.html`, ignoreThisOne ? null : HTML);


### PR DESCRIPTION
Adds a direct link to the object data source in each meta file.  This will trigger a change in every file.

Sample output...
https://github.com/cagov/automation-development-target/commit/338ce99bb7906deddbf7d95d3f57c895b4dce4d2
```
    "api_url": "https://as-go-covid19-d-001.azurewebsites.net/wp-json/wp/v2/",
    "object_url": "https://as-go-covid19-d-001.azurewebsites.net/wp-json/wp/v2/pages/8932",
```