### PR TITLE
adding 500,502,504 http status codes to retry

### DIFF
--- a/wordpress-to-github/common/index.js
+++ b/wordpress-to-github/common/index.js
@@ -6,7 +6,8 @@ const {
 } = require("../gitTreeCommon");
 const fetchRetry = require("fetch-retry")(require("node-fetch/lib"), {
   retries: 3,
-  retryDelay: 2000
+  retryDelay: 5000,
+  retryOn: [500, 502, 504]
 });
 
 /**


### PR DESCRIPTION
for https://github.com/cagov/wordpress-to-github/issues/87

Also expanding delay timer to 5 seconds instead of 2.