### PR TITLE
Removing Broken Azure Tools References

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
-azure-functions-core-tools/.telemetry/20200331222905_2f21fc7f736d45fa9be029b90391935f.trn
-
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "ms-azuretools.vscode-azurefunctions",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "tombonnike.vscode-status-bar-format-toggle"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Attach to Node Functions",
-      "type": "node",
-      "request": "attach",
-      "port": 9229,
-      "preLaunchTask": "func: host start"
-    },
-    {
       "type": "node",
       "request": "launch",
       "name": "Debug DIRECT WordpressSync",
       "program": "debug.js",
-      "args": ["1"],
+      "args": [
+        "1"
+      ],
       "cwd": "${workspaceRoot}/WordpressSync",
       "outputCapture": "std"
     },
@@ -22,7 +17,9 @@
       "request": "launch",
       "name": "Debug 3X DIRECT WordpressSync",
       "program": "debug.js",
-      "args": ["3"],
+      "args": [
+        "3"
+      ],
       "cwd": "${workspaceRoot}/WordpressSync",
       "outputCapture": "std"
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,6 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "func",
-      "command": "host start",
-      "problemMatcher": "$func-watch",
-      "isBackground": true,
-      "dependsOn": "npm install"
-    },
-    {
       "type": "shell",
       "label": "npm install",
       "command": "npm install"


### PR DESCRIPTION
Removing broken Azure Tool references, because they don't work in their current state.  If needed, someone could go through the trouble of re-installing.