### PR TITLE
Fix problem with recently deleted media

### DIFF
--- a/wordpress-to-github/index.js
+++ b/wordpress-to-github/index.js
@@ -293,8 +293,18 @@ const SyncEndpoint = async (
     });
 
     //Figure out which meta files changed...
-    const mediaChanges = (await mediaTree.treePushDryRun()).map(
-      p => mediaMap.get(p.replace(`${endpointConfig.MediaPath}/`, "")).data
+    const mediaChanges = (await mediaTree.treePushDryRun()).reduce(
+      (bucket, p) => {
+        const mediaMapKey = p.replace(`${endpointConfig.MediaPath}/`, "");
+        const mediaMapEntry = mediaMap.get(mediaMapKey);
+        const mediaMapEntryData = mediaMapEntry?.data;
+
+        if (mediaMapEntryData) {
+          bucket.push(mediaMapEntryData);
+        }
+        return bucket;
+      },
+      []
     );
 
     if (mediaChanges.length) {

--- a/wordpress-to-github/package.json
+++ b/wordpress-to-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/wordpress-to-github",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes the problem we encountered yesterday, where recently deleted media in Wordpress can cause a crash.